### PR TITLE
Upgrade to canvas 2.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ function retricon(str, opts) {
 	var id = idhash(str, mid * dimension, opts.minFill, opts.maxFill);
 	var pic = reflect(id, dimension);
 	var csize = (pixelSize * dimension) + (opts.imagePadding * 2);
-	var c = new Canvas(csize, csize);
+	var c = Canvas.createCanvas(csize, csize);
 	var ctx = c.getContext('2d');
 	
 	

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Keith Beckman <kbeckman@becknet.com>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "canvas": "^1.6.7",
+    "canvas": "^2.3.1",
     "lodash": "3.x"
   },
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retricon",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "create indenticon-like visual hashes styled like Github and Gravatar (retro) avatars",
   "main": "index.js",
   "homepage": "https://github.com/sehrgut/node-retricon",
@@ -24,7 +24,7 @@
   "author": "Keith Beckman <kbeckman@becknet.com>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "canvas": "^1.0",
+    "canvas": "^1.6.7",
     "lodash": "3.x"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
NPM fails when trying to install node-canvas 1.x dependencie because it is deprecated.
This PR makes the changes needed to work with node-canvas 2.x.

There could be some backward compatibility breaking with the returned canvas, see: 
https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md#200